### PR TITLE
Add links to `I/O customization variable` in glossary

### DIFF
--- a/html_in/Glossary.html
+++ b/html_in/Glossary.html
@@ -2782,14 +2782,14 @@ to disambiguate.
 </p>
 <table>
   <tr>
-    <td><a href="002adebug_002dio_002a.html">*debug-io*</a></td>
-    <td>*error-io*</td>
-    <td><a href="002adebug_002dio_002a.html">*query-io*</a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*debug-io*</b></a></td>
+    <td><b>*error-io*</b></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*query-io*</b></a></td>
   </tr>
   <tr>
-    <td><a href="002adebug_002dio_002a.html">*standard-input*</a></td>
-    <td><a href="002adebug_002dio_002a.html">*standard-output*</a></td>
-    <td><a href="002adebug_002dio_002a.html">*trace-output*</a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*standard-input*</b></a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*standard-output*</b></a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*trace-output*</b></a></td>
   </tr>
 </table>
 <p>&nbsp;&nbsp;Figure&nbsp;26&ndash;2:&nbsp;Standardized&nbsp;I/O&nbsp;Customization&nbsp;Variables

--- a/html_in/Glossary.html
+++ b/html_in/Glossary.html
@@ -2781,8 +2781,16 @@ to disambiguate.
       to be an <i>I/O customization variable</i>.
 </p>
 <table>
-	<tr><td><a href="002adebug_002dio_002a.html">*debug-io*</a></td><td><span class="nolinebreak">*error-io*</span></td><td><span class="nolinebreak">query-io*</span></td></tr>
-	<tr><td><span class="nolinebreak">*standard-input*</span></td><td><span class="nolinebreak">*standard-output*</span></td><td><span class="nolinebreak">*trace-output*</span></td></tr>
+  <tr>
+    <td><a href="002adebug_002dio_002a.html">*debug-io*</a></td>
+    <td>*error-io*</td>
+    <td><a href="002adebug_002dio_002a.html">*query-io*</a></td>
+  </tr>
+  <tr>
+    <td><a href="002adebug_002dio_002a.html">*standard-input*</a></td>
+    <td><a href="002adebug_002dio_002a.html">*standard-output*</a></td>
+    <td><a href="002adebug_002dio_002a.html">*trace-output*</a></td>
+  </tr>
 </table>
 <p>&nbsp;&nbsp;Figure&nbsp;26&ndash;2:&nbsp;Standardized&nbsp;I/O&nbsp;Customization&nbsp;Variables
 </p>
@@ -6061,18 +6069,17 @@ to disambiguate.
 </dd>
 </dl>
 
-
-
-
-
+<h4 class="subsubheading">Errata::</h4>
+<p><i>This section lists errata in the ANSI standard that have been amended in this CLCS entry.</i></p>
+<ul>
+  <li>The glossary entry for <a href="#I_002fO-customization-variable"><i>I/O customization variable</i></a> contains a typo: <a href="002adebug_002dio_002a.html">*query-io*</a> is missing its first asterisk.</li>
+</ul>
 
 <hr>
 <div class="header">
 <p>
 Previous: <a href="Glossary-_0028Glossary_0029.html#Glossary-_0028Glossary_0029" accesskey="p" rel="prev">Glossary (Glossary)</a>, Up: <a href="Glossary-_0028Glossary_0029.html#Glossary-_0028Glossary_0029" accesskey="u" rel="up">Glossary (Glossary)</a> &nbsp; </p>
 </div>
-
-
 
 </body>
 </html>

--- a/html_in/Glossary.html
+++ b/html_in/Glossary.html
@@ -6072,7 +6072,7 @@ to disambiguate.
 <h4 class="subsubheading">Errata::</h4>
 <p><i>This section lists errata in the ANSI standard that have been amended in this CLCS entry.</i></p>
 <ul>
-  <li>The glossary entry for <a href="#I_002fO-customization-variable"><i>I/O customization variable</i></a> contains a typo: <a href="002adebug_002dio_002a.html">*query-io*</a> is missing its first asterisk.</li>
+  <li>The glossary entry for <a href="#I_002fO-customization-variable"><i>I/O customization variable</i></a> contains a typo: <code>*query-io*</code> is missing its first asterisk.</li>
 </ul>
 
 <hr>

--- a/html_out/Glossary.html
+++ b/html_out/Glossary.html
@@ -2866,8 +2866,16 @@ to disambiguate.
       to be an <i>I/O customization variable</i>.
 </p>
 <table>
-	<tr><td><a href="002adebug_002dio_002a.html">*debug-io*</a></td><td><span class="nolinebreak">*error-io*</span></td><td><span class="nolinebreak">query-io*</span></td></tr>
-	<tr><td><span class="nolinebreak">*standard-input*</span></td><td><span class="nolinebreak">*standard-output*</span></td><td><span class="nolinebreak">*trace-output*</span></td></tr>
+  <tr>
+    <td><a href="002adebug_002dio_002a.html">*debug-io*</a></td>
+    <td>*error-io*</td>
+    <td><a href="002adebug_002dio_002a.html">*query-io*</a></td>
+  </tr>
+  <tr>
+    <td><a href="002adebug_002dio_002a.html">*standard-input*</a></td>
+    <td><a href="002adebug_002dio_002a.html">*standard-output*</a></td>
+    <td><a href="002adebug_002dio_002a.html">*trace-output*</a></td>
+  </tr>
 </table>
 <div class="table-subcaption"> Figure 26&ndash;2: Standardized I/O Customization Variables</div>
 
@@ -6171,12 +6179,13 @@ to disambiguate.
 </dd>
 </dl>
 
-
-
-
-
-
-
+</div>
+<div class="section">
+<h4 class="subsubheading">Errata</h4>
+<p><i>This section lists errata in the ANSI standard that have been amended in this CLCS entry.</i></p>
+<ul>
+  <li>The glossary entry for <a href="#I_002fO-customization-variable"><i>I/O customization variable</i></a> contains a typo: <a href="002adebug_002dio_002a.html">*query-io*</a> is missing its first asterisk.</li>
+</ul>
 
 
 </div>

--- a/html_out/Glossary.html
+++ b/html_out/Glossary.html
@@ -2867,14 +2867,14 @@ to disambiguate.
 </p>
 <table>
   <tr>
-    <td><a href="002adebug_002dio_002a.html">*debug-io*</a></td>
-    <td>*error-io*</td>
-    <td><a href="002adebug_002dio_002a.html">*query-io*</a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*debug-io*</b></a></td>
+    <td><b>*error-io*</b></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*query-io*</b></a></td>
   </tr>
   <tr>
-    <td><a href="002adebug_002dio_002a.html">*standard-input*</a></td>
-    <td><a href="002adebug_002dio_002a.html">*standard-output*</a></td>
-    <td><a href="002adebug_002dio_002a.html">*trace-output*</a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*standard-input*</b></a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*standard-output*</b></a></td>
+    <td><a href="002adebug_002dio_002a.html"><b>*trace-output*</b></a></td>
   </tr>
 </table>
 <div class="table-subcaption"> Figure 26&ndash;2: Standardized I/O Customization Variables</div>

--- a/html_out/Glossary.html
+++ b/html_out/Glossary.html
@@ -6184,7 +6184,7 @@ to disambiguate.
 <h4 class="subsubheading">Errata</h4>
 <p><i>This section lists errata in the ANSI standard that have been amended in this CLCS entry.</i></p>
 <ul>
-  <li>The glossary entry for <a href="#I_002fO-customization-variable"><i>I/O customization variable</i></a> contains a typo: <a href="002adebug_002dio_002a.html">*query-io*</a> is missing its first asterisk.</li>
+  <li>The glossary entry for <a href="#I_002fO-customization-variable"><i>I/O customization variable</i></a> contains a typo: <code>*query-io*</code> is missing its first asterisk.</li>
 </ul>
 
 


### PR DESCRIPTION
I added links to the table under the glossary entry for [I/O customization variable](https://cl-community-spec.github.io/pages/Glossary.html#I_002fO-customization-variable). I removed the spans with the `nolinebreak` class, since this class is not being used by `styles.css`.

The table contains a mysterious `*error-io*` variable, which [I think is a mistake](https://irclog.tymoon.eu/libera/%23commonlisp?around=1488555240#1488555240), so I didn't make it a link.

Additionally, I fixed a missing asterisk in `*query-io*`. Seems like another [issue in the standard](https://github.com/fonol/cl-community-spec/issues/17), since this mistake is also in CLHS.