### PR TITLE
Remove `b` tags from examples

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -133,11 +133,13 @@ function toggleTheme() {
 // syntax highlighting
 (() => {
     for (let el of document.getElementsByTagName('code')) {
+        el.innerHTML = el.innerHTML
+            .replace(/<br>/g, '\n')
+            .replace(/<i\/?>/g, '')
+            .replace(/<b\/?>/g, '')
+            .replace(/<code\/?>/g, '');
+
         if (!el.classList.contains('no-highlight')) {
-            el.innerHTML = el.innerHTML
-                .replace(/<br>/g, '\n')
-                .replace(/<i\/?>/g, '')
-                .replace(/<code\/?>/g, '');
             HighlightLisp.highlight_element(el);
         }
     }

--- a/scripts.js
+++ b/scripts.js
@@ -134,11 +134,10 @@ function toggleTheme() {
 (() => {
     for (let el of document.getElementsByTagName('code')) {
         el.innerHTML = el.innerHTML
-            .replace(/<br>/g, '\n')
-            .replace(/<i\/?>/g, '')
-            .replace(/<b\/?>/g, '')
-            .replace(/<code\/?>/g, '');
-
+            .replace(/<br\/?>/g, '\n')
+            .replace(/<\/?i>/g, '')
+            .replace(/<\/?b>/g, '')
+            .replace(/<\/?code[^>]+>/g, '');
         if (!el.classList.contains('no-highlight')) {
             HighlightLisp.highlight_element(el);
         }


### PR DESCRIPTION
Some pages like [assert](https://cl-community-spec.github.io/pages/assert.html) have `<b>` tags in the examples. This commit doesn't remove them from the HTML, but uses JS to hide them.